### PR TITLE
🐛 Use non-deprecated `collections.abc.AsyncIterator` instead of `typing.AsyncIterator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ async def read_root(request: Request):
 Using the lifespan state, you'd do something like this:
 
 ```py
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 from fastapi import FastAPI, Request
 from httpx import AsyncClient


### PR DESCRIPTION
# Problem

* Tip 6 example uses `typing.AsyncIterator`
* `typing.AsyncIterator` is [deprecated since python 3.9](https://docs.python.org/3/library/typing.html#typing.AsyncIterator)

# Solution

* Use [`collections.abc.AsyncIterator`](https://docs.python.org/3/library/collections.abc.html#collections.abc.AsyncIterator) that now supports subscripting (`[]`)

# Note

* Am I nitpicking? Feel comfortable closing this PR.
* Thanks a ton for starting this.