### PR TITLE
Use transport parameter in httpx.AsyncClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ assert response.json() == {"Hello": "World"}
 
 # Using AsyncClient
 import anyio
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 
 async def main():
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/")
         assert response.status_code == 200
         assert response.json() == {"Hello": "World"}
@@ -176,7 +176,7 @@ from typing import AsyncIterator
 
 import anyio
 from asgi_lifespan import LifespanManager
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI
 
 
@@ -197,7 +197,7 @@ async def read_root():
 
 async def main():
     async with LifespanManager(app, lifespan) as manager:
-        async with AsyncClient(app=manager.app) as client:
+        async with AsyncClient(transport=ASGITransport(app=manager.app)) as client:
             response = await client.get("/")
             assert response.status_code == 200
             assert response.json() == {"Hello": "World"}


### PR DESCRIPTION
Fixes #16 

Note that it currently makes `pyright` unhappy with 

```bash
 Argument of type "FastAPI" cannot be assigned to parameter "app" of type "_ASGIApp" in function "__init__"
```
but I believe this will be fixed when https://github.com/encode/httpx/pull/3109 is released, so I'm not adding any `# type: ignore` for the sake of simplicity.