### PR TITLE
🐛 Remove `lifespan` parameter from `LifespanManager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ async def read_root():
 
 
 async def main():
-    async with LifespanManager(app, lifespan) as manager:
+    async with LifespanManager(app) as manager:
         async with AsyncClient(transport=ASGITransport(app=manager.app)) as client:
             response = await client.get("/")
             assert response.status_code == 200


### PR DESCRIPTION
Remove incorrect `, lifespan` from README.md in order to fix #20 