### PR TITLE
fix: uvicorn.org -> uvicorn.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ def anyio_backend():
 You can read more about it on the
 [`anyio` documentation](https://anyio.readthedocs.io/en/stable/testing.html#specifying-the-backends-to-run-on).
 
-[uvicorn]: https://www.uvicorn.org/
+[uvicorn]: https://uvicorn.dev/
 [run_sync]: https://anyio.readthedocs.io/en/stable/threads.html#running-a-function-in-a-worker-thread
 [run_in_threadpool]: https://github.com/encode/starlette/blob/9f16bf5c25e126200701f6e04330864f4a91a898/starlette/concurrency.py#L36-L42
 [increase-threadpool]: https://anyio.readthedocs.io/en/stable/threads.html#adjusting-the-default-maximum-worker-thread-count


### PR DESCRIPTION
# Problem

* https://uvicorn.org is a dead link

# Solution

* http://uvicorn.dev